### PR TITLE
Fix definition file generation issue

### DIFF
--- a/docs/drafts-definitions.js
+++ b/docs/drafts-definitions.js
@@ -1131,7 +1131,9 @@ declare class Draft {
 /**
  * The current draft points to the draft open in the editor when the action was run.
  */
-declare const draft: Drafttype dropboxMode = 'add' | 'overwrite'
+declare const draft: Draft
+
+type dropboxMode = 'add' | 'overwrite'
 
 interface DropboxRequestSettings {
     /**

--- a/src/Draft.d.ts
+++ b/src/Draft.d.ts
@@ -254,3 +254,4 @@ declare class Draft {
  * The current draft points to the draft open in the editor when the action was run.
  */
 declare const draft: Draft
+


### PR DESCRIPTION
Line 1134 of drafts-definitions.js was a single concatenation of the draft definition and the dropboxMode type definition.

```
declare const draft: Draft type dropboxMode = 'add' | 'overwrite'
```

Modified the Draft.d.ts file to force a blank line between when the `build.sh` script is run (concatenating the source files including the nes for Drafts and Dropbox.